### PR TITLE
Don't cancel the ctx after a handler returns

### DIFF
--- a/items.go
+++ b/items.go
@@ -260,17 +260,17 @@ func (r *ItemRequest) Copy(dest *ItemRequest) {
 }
 
 // Context returns a context and cancel function representing the timeout for this request
-func (r *ItemRequest) TimeoutContext() (context.Context, context.CancelFunc) {
+func (r *ItemRequest) TimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if r == nil || r.Timeout == nil {
-		return context.WithCancel(context.Background())
+		return context.WithCancel(ctx)
 	}
 
 	// If the timeout is 0, treat that as infinite
 	if r.Timeout.Nanos == 0 && r.Timeout.Seconds == 0 {
-		return context.WithCancel(context.Background())
+		return context.WithCancel(ctx)
 	}
 
-	return context.WithTimeout(context.Background(), r.Timeout.AsDuration())
+	return context.WithTimeout(ctx, r.Timeout.AsDuration())
 }
 
 // ToAttributes Convers a map[string]interface{} to an ItemAttributes object

--- a/items_test.go
+++ b/items_test.go
@@ -1,6 +1,7 @@
 package sdp
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -419,7 +420,7 @@ func TestTimeoutContext(t *testing.T) {
 		Timeout:     durationpb.New(10 * time.Millisecond),
 	}
 
-	ctx, cancel := r.TimeoutContext()
+	ctx, cancel := r.TimeoutContext(context.Background())
 	defer cancel()
 
 	select {

--- a/tracing.go
+++ b/tracing.go
@@ -31,8 +31,7 @@ func NewOtelExtractingHandler(spanName string, h CtxMsgHandler, t trace.Tracer, 
 	}
 
 	return func(msg *nats.Msg) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := context.Background()
 
 		ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(msg.Header))
 


### PR DESCRIPTION
As it turns out this was not helpful. Handlers often spawn off additional background tasks belonging to the same "business request" that also needs to be traced in this context.