### PR TITLE
Implement per-connect account names in NATSOptions and TokenClient

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -34,7 +34,7 @@ func TestBasicTokenClient(t *testing.T) {
 
 	var token string
 
-	token, err = c.GetJWT()
+	token, err = c.GetJWTWithAccount("")
 
 	if err != nil {
 		t.Error(err)
@@ -92,7 +92,6 @@ func GetTestOAuthTokenClient(t *testing.T) *natsTokenClient {
 	flowConfig := ClientCredentialsConfig{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Account:      "org_hdeUXbB55sMMvJLa",
 	}
 
 	return NewOAuthTokenClient(
@@ -107,7 +106,7 @@ func TestOAuthTokenClient(t *testing.T) {
 
 	var err error
 
-	_, err = c.GetJWT()
+	_, err = c.GetJWTWithAccount("")
 
 	if err != nil {
 		t.Error(err)

--- a/auth/nats_test.go
+++ b/auth/nats_test.go
@@ -31,7 +31,7 @@ func TestToNatsOptions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		server, options := o.ToNatsOptions()
+		server, options := o.ToNatsOptions("")
 
 		if server != "" {
 			t.Error("Expected server to be empty")
@@ -121,7 +121,7 @@ func TestToNatsOptions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		server, options := o.ToNatsOptions()
+		server, options := o.ToNatsOptions("")
 
 		if server != "one,two" {
 			t.Errorf("Expected server to be one,two got %v", server)
@@ -202,7 +202,7 @@ func TestNATSConnect(t *testing.T) {
 
 		start := time.Now()
 
-		_, err := o.Connect()
+		_, err := o.ConnectAs("")
 
 		// Just sanity check the duration here, it should be less than 1s and it
 		// should be more than... Some larger number of seconds. This is very
@@ -226,7 +226,7 @@ func TestNATSConnect(t *testing.T) {
 	t.Run("with a bad URL, but a good token", func(t *testing.T) {
 		tk := GetTestOAuthTokenClient(t)
 
-		startToken, err := tk.GetJWT()
+		startToken, err := tk.GetJWTWithAccount("")
 
 		if err != nil {
 			t.Fatal(err)
@@ -239,12 +239,12 @@ func TestNATSConnect(t *testing.T) {
 			RetryDelay:  100 * time.Millisecond,
 		}
 
-		_, err = o.Connect()
+		_, err = o.ConnectAs("")
 
 		switch err.(type) {
 		case MaxRetriesError:
 			// Make sure we have only got one token, not three
-			currentToken, err := o.TokenClient.GetJWT()
+			currentToken, err := o.TokenClient.GetJWTWithAccount("")
 
 			if err != nil {
 				t.Fatal(err)
@@ -268,7 +268,7 @@ func TestNATSConnect(t *testing.T) {
 			RetryDelay: 100 * time.Millisecond,
 		}
 
-		conn, err := o.Connect()
+		conn, err := o.ConnectAs("")
 
 		if err != nil {
 			t.Fatal(err)
@@ -285,7 +285,7 @@ func TestNATSConnect(t *testing.T) {
 			},
 		}
 
-		conn, err := o.Connect()
+		conn, err := o.ConnectAs("")
 
 		if err != nil {
 			t.Fatal(err)
@@ -304,7 +304,7 @@ func TestNATSConnect(t *testing.T) {
 			RetryDelay: 100 * time.Millisecond,
 		}
 
-		conn, err := o.Connect()
+		conn, err := o.ConnectAs("")
 
 		if err != nil {
 			t.Error(err)
@@ -318,7 +318,7 @@ func TestTokenRefresh(t *testing.T) {
 	tk := GetTestOAuthTokenClient(t)
 
 	// Get a token
-	token, err := tk.GetJWT()
+	token, err := tk.GetJWTWithAccount("")
 
 	if err != nil {
 		t.Fatal(err)
@@ -346,7 +346,7 @@ func TestTokenRefresh(t *testing.T) {
 	}
 
 	// Get the token again
-	newToken, err := tk.GetJWT()
+	newToken, err := tk.GetJWTWithAccount("")
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
In most cases the account name is baked into the underlying token client (e.g. when using API Keys). Only in some tests we were injecting an account name which was baked into the underlying token client too.

This is a breaking change. I've got patches for everything on my machine and it doesn't look awful. Will upload once this is merged and tagged.