### PR TITLE
SDPWS Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/auth0/go-jwt-middleware/v2 v2.1.0
 	github.com/getsentry/sentry-go v0.25.0
 	github.com/go-jose/go-jose/v3 v3.0.0
-	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.4.0
 	github.com/nats-io/jwt/v2 v2.5.2
 	github.com/nats-io/nats.go v1.31.0
@@ -28,6 +27,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/klauspost/compress v1.17.0 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/auth0/go-jwt-middleware/v2 v2.1.0
 	github.com/getsentry/sentry-go v0.25.0
 	github.com/go-jose/go-jose/v3 v3.0.0
+	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.4.0
 	github.com/nats-io/jwt/v2 v2.5.2
 	github.com/nats-io/nats.go v1.31.0
@@ -17,15 +18,16 @@ require (
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/sdk v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/oauth2 v0.13.0
 	google.golang.org/protobuf v1.31.0
+	nhooyr.io/websocket v1.8.10
 )
 
 require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/klauspost/compress v1.17.0 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
-github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
@@ -36,8 +34,6 @@ github.com/nats-io/jwt/v2 v2.5.2 h1:DhGH+nKt+wIkDxM6qnVSKjokq5t59AZV5HRcFW0zJwU=
 github.com/nats-io/jwt/v2 v2.5.2/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
 github.com/nats-io/nats.go v1.31.0 h1:/WFBHEc/dOKBF6qf1TZhrdEfTmOZ5JzdJ+Y3m6Y/p7E=
 github.com/nats-io/nats.go v1.31.0/go.mod h1:di3Bm5MLsoB4Bx61CBTsxuarI36WbhAwOm8QrW39+i8=
-github.com/nats-io/nkeys v0.4.5 h1:Zdz2BUlFm4fJlierwvGK+yl20IAKUm7eV6AAZXEhkPk=
-github.com/nats-io/nkeys v0.4.5/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
 github.com/nats-io/nkeys v0.4.6 h1:IzVe95ru2CT6ta874rt9saQRkWfe2nFj1NtvYSLqMzY=
 github.com/nats-io/nkeys v0.4.6/go.mod h1:4DxZNzenSVd1cYQoAa8948QY3QDjrHfcfVADymtkpts=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ go.opentelemetry.io/otel/sdk v1.19.0 h1:6USY6zH+L8uMH8L3t1enZPR3WFEmSTADlqldyHtJ
 go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+GfzpjUvI0v1A=
 go.opentelemetry.io/otel/trace v1.19.0 h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1Dzxpg=
 go.opentelemetry.io/otel/trace v1.19.0/go.mod h1:mfaSyvGyEJEI0nyV2I4qhNQnbBOUUmYZpYojqMnX2vo=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
@@ -96,3 +98,5 @@ gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
+nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/sdpws/client.go
+++ b/sdpws/client.go
@@ -139,6 +139,7 @@ func (c *Client) receive(ctx context.Context) {
 				c.handler.NewItem(ctx, item)
 			}
 			c.postRequestChan(uuid.UUID(item.Metadata.SourceQuery.UUID), msg)
+
 		case *sdp.GatewayResponse_NewEdge:
 			edge := msg.GetNewEdge()
 			if c.handler != nil {
@@ -150,12 +151,66 @@ func (c *Client) receive(ctx context.Context) {
 			// if ok {
 			// 	c <- msg
 			// }
+
+		case *sdp.GatewayResponse_Status:
+			status := msg.GetStatus()
+			if c.handler != nil {
+				c.handler.Status(ctx, status)
+			}
+
 		case *sdp.GatewayResponse_QueryError:
 			qe := msg.GetQueryError()
 			if c.handler != nil {
 				c.handler.QueryError(ctx, qe)
 			}
 			c.postRequestChan(uuid.UUID(qe.UUID), msg)
+
+		case *sdp.GatewayResponse_DeleteItem:
+			item := msg.GetDeleteItem()
+			if c.handler != nil {
+				c.handler.DeleteItem(ctx, item)
+			}
+
+		case *sdp.GatewayResponse_DeleteEdge:
+			edge := msg.GetDeleteEdge()
+			if c.handler != nil {
+				c.handler.DeleteEdge(ctx, edge)
+			}
+
+		case *sdp.GatewayResponse_UpdateItem:
+			item := msg.GetUpdateItem()
+			if c.handler != nil {
+				c.handler.UpdateItem(ctx, item)
+			}
+
+		case *sdp.GatewayResponse_SnapshotStoreResult:
+			result := msg.GetSnapshotStoreResult()
+			if c.handler != nil {
+				c.handler.SnapshotStoreResult(ctx, result)
+			}
+			c.postRequestChan(uuid.UUID(result.MsgID), msg)
+
+		case *sdp.GatewayResponse_SnapshotLoadResult:
+			result := msg.GetSnapshotLoadResult()
+			if c.handler != nil {
+				c.handler.SnapshotLoadResult(ctx, result)
+			}
+			c.postRequestChan(uuid.UUID(result.MsgID), msg)
+
+		case *sdp.GatewayResponse_BookmarkStoreResult:
+			result := msg.GetBookmarkStoreResult()
+			if c.handler != nil {
+				c.handler.BookmarkStoreResult(ctx, result)
+			}
+			c.postRequestChan(uuid.UUID(result.MsgID), msg)
+
+		case *sdp.GatewayResponse_BookmarkLoadResult:
+			result := msg.GetBookmarkLoadResult()
+			if c.handler != nil {
+				c.handler.BookmarkLoadResult(ctx, result)
+			}
+			c.postRequestChan(uuid.UUID(result.MsgID), msg)
+
 		case *sdp.GatewayResponse_QueryStatus:
 			qs := msg.GetQueryStatus()
 			if c.handler != nil {
@@ -167,6 +222,7 @@ func (c *Client) receive(ctx context.Context) {
 			case sdp.QueryStatus_FINISHED, sdp.QueryStatus_CANCELLED, sdp.QueryStatus_ERRORED:
 				c.finishRequestChan(uuid.UUID(qs.UUID))
 			}
+
 		default:
 			log.WithContext(ctx).WithField("response", msg).WithField("responseType", fmt.Sprintf("%T", msg.ResponseType)).Warn("unexpected response")
 		}

--- a/sdpws/messagehandler.go
+++ b/sdpws/messagehandler.go
@@ -81,3 +81,47 @@ func (l *LoggingGatewayMessageHandler) BookmarkLoadResult(ctx context.Context, r
 func (l *LoggingGatewayMessageHandler) QueryStatus(ctx context.Context, status *sdp.QueryStatus) {
 	log.WithContext(ctx).WithField("status", status).Log(l.Level, "received query status")
 }
+
+type NoopGatewayMessageHandler struct{}
+
+// assert that NoopGatewayMessageHandler implements GatewayMessageHandler
+var _ GatewayMessageHandler = (*NoopGatewayMessageHandler)(nil)
+
+func (l *NoopGatewayMessageHandler) NewItem(ctx context.Context, item *sdp.Item) {
+}
+
+func (l *NoopGatewayMessageHandler) NewEdge(ctx context.Context, edge *sdp.Edge) {
+}
+
+func (l *NoopGatewayMessageHandler) Status(ctx context.Context, status *sdp.GatewayRequestStatus) {
+}
+
+func (l *NoopGatewayMessageHandler) Error(ctx context.Context, errorMessage string) {
+}
+
+func (l *NoopGatewayMessageHandler) QueryError(ctx context.Context, queryError *sdp.QueryError) {
+}
+
+func (l *NoopGatewayMessageHandler) DeleteItem(ctx context.Context, reference *sdp.Reference) {
+}
+
+func (l *NoopGatewayMessageHandler) DeleteEdge(ctx context.Context, edge *sdp.Edge) {
+}
+
+func (l *NoopGatewayMessageHandler) UpdateItem(ctx context.Context, item *sdp.Item) {
+}
+
+func (l *NoopGatewayMessageHandler) SnapshotStoreResult(ctx context.Context, result *sdp.SnapshotStoreResult) {
+}
+
+func (l *NoopGatewayMessageHandler) SnapshotLoadResult(ctx context.Context, result *sdp.SnapshotLoadResult) {
+}
+
+func (l *NoopGatewayMessageHandler) BookmarkStoreResult(ctx context.Context, result *sdp.BookmarkStoreResult) {
+}
+
+func (l *NoopGatewayMessageHandler) BookmarkLoadResult(ctx context.Context, result *sdp.BookmarkLoadResult) {
+}
+
+func (l *NoopGatewayMessageHandler) QueryStatus(ctx context.Context, status *sdp.QueryStatus) {
+}

--- a/sdpws/messagehandler.go
+++ b/sdpws/messagehandler.go
@@ -1,0 +1,83 @@
+package sdpws
+
+import (
+	"context"
+
+	"github.com/overmindtech/sdp-go"
+	log "github.com/sirupsen/logrus"
+)
+
+type GatewayMessageHandler interface {
+	NewItem(context.Context, *sdp.Item)
+	NewEdge(context.Context, *sdp.Edge)
+	Status(context.Context, *sdp.GatewayRequestStatus)
+	Error(context.Context, string)
+	QueryError(context.Context, *sdp.QueryError)
+	DeleteItem(context.Context, *sdp.Reference)
+	DeleteEdge(context.Context, *sdp.Edge)
+	UpdateItem(context.Context, *sdp.Item)
+	SnapshotStoreResult(context.Context, *sdp.SnapshotStoreResult)
+	SnapshotLoadResult(context.Context, *sdp.SnapshotLoadResult)
+	BookmarkStoreResult(context.Context, *sdp.BookmarkStoreResult)
+	BookmarkLoadResult(context.Context, *sdp.BookmarkLoadResult)
+	QueryStatus(context.Context, *sdp.QueryStatus)
+}
+
+type LoggingGatewayMessageHandler struct {
+	Level log.Level
+}
+
+// assert that LoggingGatewayMessageHandler implements GatewayMessageHandler
+var _ GatewayMessageHandler = (*LoggingGatewayMessageHandler)(nil)
+
+func (l *LoggingGatewayMessageHandler) NewItem(ctx context.Context, item *sdp.Item) {
+	log.WithContext(ctx).WithField("item", item).Log(l.Level, "received new item")
+}
+
+func (l *LoggingGatewayMessageHandler) NewEdge(ctx context.Context, edge *sdp.Edge) {
+	log.WithContext(ctx).WithField("edge", edge).Log(l.Level, "received new edge")
+}
+
+func (l *LoggingGatewayMessageHandler) Status(ctx context.Context, status *sdp.GatewayRequestStatus) {
+	log.WithContext(ctx).WithField("status", status).Log(l.Level, "received status")
+}
+
+func (l *LoggingGatewayMessageHandler) Error(ctx context.Context, errorMessage string) {
+	log.WithContext(ctx).WithField("errorMessage", errorMessage).Log(l.Level, "received error")
+}
+
+func (l *LoggingGatewayMessageHandler) QueryError(ctx context.Context, queryError *sdp.QueryError) {
+	log.WithContext(ctx).WithField("queryError", queryError).Log(l.Level, "received query error")
+}
+
+func (l *LoggingGatewayMessageHandler) DeleteItem(ctx context.Context, reference *sdp.Reference) {
+	log.WithContext(ctx).WithField("reference", reference).Log(l.Level, "received delete item")
+}
+
+func (l *LoggingGatewayMessageHandler) DeleteEdge(ctx context.Context, edge *sdp.Edge) {
+	log.WithContext(ctx).WithField("edge", edge).Log(l.Level, "received delete edge")
+}
+
+func (l *LoggingGatewayMessageHandler) UpdateItem(ctx context.Context, item *sdp.Item) {
+	log.WithContext(ctx).WithField("item", item).Log(l.Level, "received updated item")
+}
+
+func (l *LoggingGatewayMessageHandler) SnapshotStoreResult(ctx context.Context, result *sdp.SnapshotStoreResult) {
+	log.WithContext(ctx).WithField("result", result).Log(l.Level, "received snapshot store result")
+}
+
+func (l *LoggingGatewayMessageHandler) SnapshotLoadResult(ctx context.Context, result *sdp.SnapshotLoadResult) {
+	log.WithContext(ctx).WithField("result", result).Log(l.Level, "received snapshot load result")
+}
+
+func (l *LoggingGatewayMessageHandler) BookmarkStoreResult(ctx context.Context, result *sdp.BookmarkStoreResult) {
+	log.WithContext(ctx).WithField("result", result).Log(l.Level, "received bookmark store result")
+}
+
+func (l *LoggingGatewayMessageHandler) BookmarkLoadResult(ctx context.Context, result *sdp.BookmarkLoadResult) {
+	log.WithContext(ctx).WithField("result", result).Log(l.Level, "received bookmark load result")
+}
+
+func (l *LoggingGatewayMessageHandler) QueryStatus(ctx context.Context, status *sdp.QueryStatus) {
+	log.WithContext(ctx).WithField("status", status).Log(l.Level, "received query status")
+}

--- a/sdpws/utils.go
+++ b/sdpws/utils.go
@@ -1,0 +1,106 @@
+package sdpws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/overmindtech/sdp-go"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func (c *Client) SendQuery(ctx context.Context, q *sdp.Query) error {
+	if c.Closed() {
+		return errors.New("client closed")
+	}
+
+	log.WithContext(ctx).WithField("query", q).Trace("writing query to websocket")
+	err := c.send(ctx, &sdp.GatewayRequest{
+		RequestType: &sdp.GatewayRequest_Query{
+			Query: q,
+		},
+		MinStatusInterval: durationpb.New(time.Second),
+	})
+	if err != nil {
+		// c.send already aborts
+		// c.abort(ctx, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Client) Query(ctx context.Context, q *sdp.Query) ([]*sdp.Item, error) {
+	if c.Closed() {
+		return nil, errors.New("client closed")
+	}
+
+	r := c.createRequestChan(uuid.UUID(q.UUID))
+
+	err := c.SendQuery(ctx, q)
+	if err != nil {
+		// c.SendQuery already aborts
+		// c.abort(ctx, err)
+		return nil, err
+	}
+
+	items := make([]*sdp.Item, 0)
+
+readLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case resp, more := <-r:
+			if !more {
+				break readLoop
+			}
+			switch resp.ResponseType.(type) {
+			case *sdp.GatewayResponse_NewItem:
+				item := resp.GetNewItem()
+				log.WithContext(ctx).WithField("query", q).WithField("item", item).Debug("received item")
+				items = append(items, item)
+			case *sdp.GatewayResponse_QueryError:
+				qe := resp.GetQueryError()
+				log.WithContext(ctx).WithField("query", q).WithField("queryerror", qe).Trace("received query error")
+				// ignore query errors
+				// switch qe.ErrorType {
+				// case sdp.QueryError_OTHER:
+				// 	return nil, fmt.Errorf("query error: %v", qe.ErrorString)
+				// case sdp.QueryError_TIMEOUT:
+				// 	return nil, fmt.Errorf("query timeout: %v", qe.ErrorString)
+				// case sdp.QueryError_NOSCOPE:
+				// 	return nil, fmt.Errorf("query to wrong scope: %v", qe.ErrorString)
+				// case sdp.QueryError_NOTFOUND:
+				// 	continue readLoop
+				// }
+				continue readLoop
+			case *sdp.GatewayResponse_QueryStatus:
+				qs := resp.GetQueryStatus()
+				log.WithContext(ctx).WithField("query", q).WithField("querystatus", qs).Trace("received query status")
+				switch qs.Status {
+				case sdp.QueryStatus_FINISHED:
+					break readLoop
+				case sdp.QueryStatus_CANCELLED:
+					return nil, errors.New("query cancelled")
+				case sdp.QueryStatus_ERRORED:
+					// if we already received items, we can ignore the error
+					if len(items) == 0 {
+						err = errors.New("query errored")
+						// query errors should not abort the connection
+						// c.abort(ctx, err)
+						return nil, err
+					}
+					break readLoop
+				}
+			default:
+				log.WithContext(ctx).WithField("response", resp).WithField("responseType", fmt.Sprintf("%T", resp.ResponseType)).Warn("unexpected response")
+			}
+		}
+	}
+
+	c.finishRequestChan(uuid.UUID(q.UUID))
+	return items, nil
+}


### PR DESCRIPTION
This client handles the low-level message handling for talking SDP over websocket.

`utils.go` contains higher level blocking and non-blocking methods to send specific requests to the gateway. The blocking methods will collect results and errors. For the non-blocking methods, an appropriate `GatewayMessageHandler` implementation needs to be passed into `Dial()`.