### PR TITLE
Move automatic env reading in ensureValidTokenHandler to configuration

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -284,7 +284,7 @@ func NewQueryProgress(q *Query) *QueryProgress {
 	}
 }
 
-// Start Starts a given request, sending items to the supplied itemChannel. It
+// Start starts a given request, sending items to the supplied itemChannel. It
 // is up to the user to watch for completion. When the request does complete,
 // the NATS subscriptions will automatically drain and the itemChannel will be
 // closed.

--- a/sdpws/client.go
+++ b/sdpws/client.go
@@ -128,7 +128,7 @@ func (c *Client) receive(ctx context.Context) {
 
 		err = proto.Unmarshal(b.Bytes(), msg)
 		if err != nil {
-			c.abort(ctx, fmt.Errorf("error unmarshaling message: %w", err))
+			c.abort(ctx, fmt.Errorf("error unmarshalling message: %w", err))
 			return
 		}
 


### PR DESCRIPTION
This enables more flexible usage of the middleware when a service has multiple different authorization routes. The additional fallback in ensureValidTokenHandler ensures that services that do not use NewAuthConfigFromEnv do not get broken