### PR TITLE
sdpws: Propagate a `QueryError` as `error`

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,10 @@
 package sdp
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
 
 const ErrorTemplate string = `%v
 
@@ -9,6 +13,17 @@ Scope: %v
 SourceName: %v
 ItemType: %v
 ResponderName: %v`
+
+// assert interface
+var _ error = (*QueryError)(nil)
+
+func (e *QueryError) GetUUIDParsed() *uuid.UUID {
+	u, err := uuid.FromBytes(e.GetUUID())
+	if err != nil {
+		return nil
+	}
+	return &u
+}
 
 // Ensure that the QueryError is seen as a valid error in golang
 func (e *QueryError) Error() string {

--- a/items.go
+++ b/items.go
@@ -339,14 +339,6 @@ func (r *Query) ParseUuid() uuid.UUID {
 	return reqUUID
 }
 
-func (x *QueryError) GetUUIDParsed() *uuid.UUID {
-	u, err := uuid.FromBytes(x.GetUUID())
-	if err != nil {
-		return nil
-	}
-	return &u
-}
-
 func (x *CancelQuery) GetUUIDParsed() *uuid.UUID {
 	u, err := uuid.FromBytes(x.GetUUID())
 	if err != nil {

--- a/sdpws/utils.go
+++ b/sdpws/utils.go
@@ -94,7 +94,7 @@ readLoop:
 				case sdp.QueryStatus_ERRORED:
 					// if we already received items, we can ignore the error
 					if len(items) == 0 && otherErr != nil {
-						err = fmt.Errorf("query errored: %v", otherErr.String())
+						err = fmt.Errorf("query errored: %w", otherErr)
 						// query errors should not abort the connection
 						// c.abort(ctx, err)
 						return nil, err


### PR DESCRIPTION
This also moves all QueryError methods to the errors.go file.