### PR TITLE
Cache oauth2 token source to save on M2M tokens with Auth0

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -95,10 +95,9 @@ func GetTestOAuthTokenClient(t *testing.T) *natsTokenClient {
 	}
 
 	return NewOAuthTokenClient(
-		fmt.Sprintf("https://%v/oauth/token", domain),
 		exchangeURL,
 		"overmind-development",
-		flowConfig,
+		flowConfig.TokenSource(fmt.Sprintf("https://%v/oauth/token", domain)),
 	)
 }
 


### PR DESCRIPTION
While we need separate NKeys for each connection, the service M2M token from Auth0 to connect to revlink is shareable between connections.