### PR TITLE
Still sanitise after custom sanitation

### DIFF
--- a/items.go
+++ b/items.go
@@ -518,7 +518,10 @@ func sanitizeInterface(i interface{}, sortArrays bool, customTransforms Transfor
 
 	// Use the transform for this specific type if it exists
 	if tFunc, ok := customTransforms[t]; ok {
-		return tFunc(i)
+		// Reset the value and type to the transformed value. This means that
+		// even if the function returns something bad, we will then transform it
+		v = reflect.ValueOf(tFunc(i))
+		t = v.Type()
 	}
 
 	switch v.Kind() {

--- a/items.go
+++ b/items.go
@@ -375,7 +375,7 @@ func (x *UndoExpand) GetUUIDParsed() *uuid.UUID {
 // can be used to change the transform behaviour of known types to do things
 // like redaction of sensitive data or simplification of complex types.
 //
-// For example this could be used to cimpletely remove anything of type `Secret`:
+// For example this could be used to completely remove anything of type `Secret`:
 //
 // ```go
 //

--- a/items_test.go
+++ b/items_test.go
@@ -321,6 +321,32 @@ func TestCustomTransforms(t *testing.T) {
 			t.Errorf("Expected bar to be bar, got %v", somethingMap["bar"])
 		}
 	})
+	t.Run("returns nil", func(t *testing.T) {
+		type Something struct {
+			Foo string
+			Bar string
+		}
+
+		data := map[string]interface{}{
+			"something": Something{
+				Foo: "foo",
+				Bar: "bar",
+			},
+			"else": nil,
+		}
+
+		attributes, err := ToAttributesCustom(data, true, TransformMap{
+			reflect.TypeOf(Something{}): func(i interface{}) interface{} {
+				return nil
+			},
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Log(attributes)
+	})
 }
 
 func TestCopy(t *testing.T) {

--- a/items_test.go
+++ b/items_test.go
@@ -111,9 +111,8 @@ var ToAttributesTests = []ToAttributesTest{
 	{
 		Name: "Pointers",
 		Input: map[string]interface{}{
-			"pointer bool":    &Bool1,
-			"pointer string":  &Dylan,
-			"pointer to zero": NilPointerBool,
+			"pointer bool":   &Bool1,
+			"pointer string": &Dylan,
 		},
 	},
 	{
@@ -335,7 +334,7 @@ func TestCustomTransforms(t *testing.T) {
 			"else": nil,
 		}
 
-		attributes, err := ToAttributesCustom(data, true, TransformMap{
+		_, err := ToAttributesCustom(data, true, TransformMap{
 			reflect.TypeOf(Something{}): func(i interface{}) interface{} {
 				return nil
 			},
@@ -344,8 +343,6 @@ func TestCustomTransforms(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		t.Log(attributes)
 	})
 }
 

--- a/items_test.go
+++ b/items_test.go
@@ -231,45 +231,96 @@ func TestDefaultTransformMap(t *testing.T) {
 }
 
 func TestCustomTransforms(t *testing.T) {
-	type Secret struct {
-		Value string
-	}
+	t.Run("redaction", func(t *testing.T) {
+		type Secret struct {
+			Value string
+		}
 
-	data := map[string]interface{}{
-		"user": map[string]interface{}{
-			"name": "Hunter",
-			"password": Secret{
-				Value: "hunter2",
+		data := map[string]interface{}{
+			"user": map[string]interface{}{
+				"name": "Hunter",
+				"password": Secret{
+					Value: "hunter2",
+				},
 			},
-		},
-	}
+		}
 
-	attributes, err := ToAttributesCustom(data, true, TransformMap{
-		reflect.TypeOf(Secret{}): func(i interface{}) interface{} {
-			// Remove it
-			return nil
-		},
+		attributes, err := ToAttributesCustom(data, true, TransformMap{
+			reflect.TypeOf(Secret{}): func(i interface{}) interface{} {
+				// Remove it
+				return nil
+			},
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		user, err := attributes.Get("user")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		userMap, ok := user.(map[string]interface{})
+
+		if !ok {
+			t.Fatalf("Expected user to be a map, got %T", user)
+		}
+
+		if _, ok := userMap["password"]; ok {
+			t.Error("Expected password to be removed")
+		}
 	})
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("map response", func(t *testing.T) {
+		type Something struct {
+			Foo string
+			Bar string
+		}
 
-	user, err := attributes.Get("user")
+		data := map[string]interface{}{
+			"something": Something{
+				Foo: "foo",
+				Bar: "bar",
+			},
+		}
 
-	if err != nil {
-		t.Fatal(err)
-	}
+		attributes, err := ToAttributesCustom(data, true, TransformMap{
+			reflect.TypeOf(Something{}): func(i interface{}) interface{} {
+				something := i.(Something)
 
-	userMap, ok := user.(map[string]interface{})
+				return map[string]string{
+					"foo": something.Foo,
+					"bar": something.Bar,
+				}
+			},
+		})
 
-	if !ok {
-		t.Fatalf("Expected user to be a map, got %T", user)
-	}
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if _, ok := userMap["password"]; ok {
-		t.Error("Expected password to be removed")
-	}
+		something, err := attributes.Get("something")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		somethingMap, ok := something.(map[string]interface{})
+
+		if !ok {
+			t.Fatalf("Expected something to be a map, got %T", something)
+		}
+
+		if somethingMap["foo"] != "foo" {
+			t.Errorf("Expected foo to be foo, got %v", somethingMap["foo"])
+		}
+
+		if somethingMap["bar"] != "bar" {
+			t.Errorf("Expected bar to be bar, got %v", somethingMap["bar"])
+		}
+	})
 }
 
 func TestCopy(t *testing.T) {


### PR DESCRIPTION
**Forgot one thing:** We should still apply our generic sanitisation to the retults of these custom functions. That means that the functions can return anything that can be converted to protobuf, like a map[string]string. If we didn't do this a map[string]string would fail