### PR TITLE
Ensure that no further query status updates go through once done

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -655,7 +655,9 @@ func (qp *QueryProgress) ProcessResponse(ctx context.Context, response *Response
 
 		// Protect against out-of order responses. Do not mark a responder as
 		// working if it has already finished
-		if responder.lastState == ResponderState_COMPLETE {
+		if responder.lastState == ResponderState_COMPLETE ||
+			responder.lastState == ResponderState_ERROR ||
+			responder.lastState == ResponderState_CANCELLED {
 			return
 		}
 	} else {


### PR DESCRIPTION
This is another patch on this ball of mud that is query status handling. Somewhere in the stack the streams cross.