### PR TITLE
Fix auth issues introduced in v0.70.0

### DIFF
--- a/sdpconnect/keepalive_interceptor.go
+++ b/sdpconnect/keepalive_interceptor.go
@@ -157,7 +157,6 @@ func (i *KeepaliveSourcesInterceptor) wakeSources(ctx context.Context) context.C
 	go func() {
 		defer sdp.LogRecoverToReturn(ctx, "KeepaliveSourcesInterceptor.wakeSources")
 		defer close(sourcesReady)
-		defer i.updateLastCalled(ctx)
 
 		// Make the request to keep the source awake
 		_, err := i.management.KeepaliveSources(ctx, &connect.Request[sdp.KeepaliveSourcesRequest]{
@@ -165,6 +164,8 @@ func (i *KeepaliveSourcesInterceptor) wakeSources(ctx context.Context) context.C
 				WaitForHealthy: true,
 			},
 		})
+
+		i.updateLastCalled(ctx)
 
 		// Send the error to the channel
 		sourcesReady <- err


### PR DESCRIPTION
Fixes #249 

In the previous logic if there were any paths that bypassed authentication the check JWT middleware would not be executed which means the token would not be validated and the token information would not be extracted into the context. This means that any services that were checking things from context like whether scopes existed would find them empty. This is what caused the authentication issues that we saw in production.

We are now correctly checking if the path is bypassed for each request (rather than just checking if this is set at all), and then if it is not bypassed we are checking the JWT token, otherwise we are just passing through the request.

As you can see the actual change is pretty small; the offending logic in `NewAuthMiddleware` has been removed. The majority of this change is in the new test suite which kicks ass. It tests the complete middleware without any mocking at all. In order to do this I've had to create a fully fledged JWT issuing service, complete with JWKS endpoints for hosting public keys so the tokens can be externally validated