### PR TITLE
breaking: require responderId for ResponseSender

### DIFF
--- a/auth/nats_test.go
+++ b/auth/nats_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
@@ -377,9 +378,11 @@ func ValidateNATSConnection(t *testing.T, ec sdp.EncodedConnection) {
 		t.Error(err)
 	}
 
+	ru := uuid.New()
 	err = ec.Publish(context.Background(), "test", &sdp.QueryResponse{ResponseType: &sdp.QueryResponse_Response{Response: &sdp.Response{
-		Responder: "test",
-		State:     sdp.ResponderState_COMPLETE,
+		Responder:     "test",
+		ResponderUUID: ru[:],
+		State:         sdp.ResponderState_COMPLETE,
 	}}})
 
 	if err != nil {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -20,9 +20,9 @@ var query = Query{
 	RecursionBehaviour: &Query_RecursionBehaviour{
 		LinkDepth: 10,
 	},
-	Scope:   "test",
-	UUID:    _u[:],
-	Deadline:    timestamppb.New(time.Now().Add(10 * time.Second)),
+	Scope:    "test",
+	UUID:     _u[:],
+	Deadline: timestamppb.New(time.Now().Add(10 * time.Second)),
 }
 
 var itemAttributes = ItemAttributes{
@@ -84,9 +84,12 @@ var queryError = QueryError{
 	Scope:       "test",
 }
 
+var ru = uuid.New()
+
 var response = Response{
-	Responder: "test",
-	State:     ResponderState_WORKING,
+	Responder:     "test",
+	ResponderUUID: ru[:],
+	State:         ResponderState_WORKING,
 	NextUpdateIn: &durationpb.Duration{
 		Seconds: 10,
 		Nanos:   0,

--- a/validation_test.go
+++ b/validation_test.go
@@ -422,11 +422,14 @@ func newQueryError() *QueryError {
 func newResponse() *Response {
 	u := uuid.New()
 
+	ru := uuid.New()
+
 	return &Response{
-		Responder:    "foo",
-		State:        ResponderState_WORKING,
-		NextUpdateIn: durationpb.New(time.Second),
-		UUID:         u[:],
+		Responder:     "foo",
+		ResponderUUID: ru[:],
+		State:         ResponderState_WORKING,
+		NextUpdateIn:  durationpb.New(time.Second),
+		UUID:          u[:],
 	}
 }
 


### PR DESCRIPTION
This is part of the fix for sources with the same name overriding each other's status during query resolution. The fix requires a unique ID for each responder, therefore it is necessary to break callers to force them to provide the new data.