### PR TITLE
Include null values in proto structs

### DIFF
--- a/items.go
+++ b/items.go
@@ -382,7 +382,7 @@ func (x *UndoExpand) GetUUIDParsed() *uuid.UUID {
 //	TransformMap{
 //		reflect.TypeOf(Secret{}): func(i interface{}) interface{} {
 //			// Remove it
-//			return nil
+//			return "REDACTED"
 //		},
 //	}
 //

--- a/items.go
+++ b/items.go
@@ -423,18 +423,7 @@ func toAttributes(m map[string]interface{}, sort bool, customTransforms Transfor
 
 	// Loop over the map
 	for k, v := range m {
-		if v == nil {
-			// If the value is nil then ignore
-			continue
-		}
-
 		sanitizedValue := sanitizeInterface(v, sort, customTransforms)
-
-		if sanitizedValue == nil {
-			// Don't include nil values
-			continue
-		}
-
 		structValue, err := structpb.NewValue(sanitizedValue)
 
 		if err != nil {
@@ -593,13 +582,8 @@ func sanitizeInterface(i interface{}, sortArrays bool, customTransforms Transfor
 			stringKey := fmt.Sprint(mapKey.Interface())
 
 			// Convert the value to a compatible interface
-			zeroValueInterface := reflect.Zero(v.MapIndex(mapKey).Type()).Interface()
 			value := sanitizeInterface(v.MapIndex(mapKey).Interface(), sortArrays, customTransforms)
-
-			// Only use the item if it isn't zero
-			if !reflect.DeepEqual(value, zeroValueInterface) {
-				returnMap[stringKey] = value
-			}
+			returnMap[stringKey] = value
 		}
 
 		return returnMap

--- a/items_test.go
+++ b/items_test.go
@@ -247,7 +247,7 @@ func TestCustomTransforms(t *testing.T) {
 		attributes, err := ToAttributesCustom(data, true, TransformMap{
 			reflect.TypeOf(Secret{}): func(i interface{}) interface{} {
 				// Remove it
-				return nil
+				return "REDACTED"
 			},
 		})
 
@@ -267,8 +267,10 @@ func TestCustomTransforms(t *testing.T) {
 			t.Fatalf("Expected user to be a map, got %T", user)
 		}
 
-		if _, ok := userMap["password"]; ok {
-			t.Error("Expected password to be removed")
+		pass, _ := userMap["password"]
+
+		if pass != "REDACTED" {
+			t.Errorf("Expected password to be REDACTED, got %v", pass)
 		}
 	})
 


### PR DESCRIPTION
Previously we were excluding null and zero values, but it doesn't really make sense to do this at the ToAttributes level since protobuf structs are perfectly capable of representing null and zero values.

I don't think this should much of a negative effect, and if we want to be filtering things out, we should be doing it at the business logic layer, not here