### PR TITLE
Add debug logging for auth token selection; Expose the new ConfigurationService

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nats-io/nkeys"
 	"github.com/overmindtech/sdp-go"
 	"github.com/overmindtech/sdp-go/sdpconnect"
+	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/oauth2"
@@ -200,8 +201,18 @@ func (n *natsTokenClient) generateJWT(ctx context.Context) error {
 	var response *connect.Response[sdp.CreateTokenResponse]
 	if n.Account == "" {
 		// Use the regular API and let the client authentication determine what our org should be
+		log.WithFields(log.Fields{
+			"account":    n.Account,
+			"publicNKey": req.UserPublicNkey,
+			"UserName":   req.UserName,
+		}).Trace("Using regular API to get NATS token")
 		response, err = n.mgmtClient.CreateToken(ctx, connect.NewRequest(req))
 	} else {
+		log.WithFields(log.Fields{
+			"account":    n.Account,
+			"publicNKey": req.UserPublicNkey,
+			"UserName":   req.UserName,
+		}).Trace("Using admin API to get NATS token")
 		// Explicitly request an org
 		response, err = n.adminClient.CreateToken(ctx, connect.NewRequest(&sdp.AdminCreateTokenRequest{
 			Account: n.Account,

--- a/auth/auth_client.go
+++ b/auth/auth_client.go
@@ -92,12 +92,12 @@ func AuthenticatedChangesClient(ctx context.Context, apiUrl string) sdpconnect.C
 	return sdpconnect.NewChangesServiceClient(httpClient, apiUrl)
 }
 
-// AuthenticatedConfigClient Returns a bookmark client that uses the auth
+// AuthenticatedConfigurationClient Returns a bookmark client that uses the auth
 // embedded in the context and otel instrumentation
-func AuthenticatedConfigClient(ctx context.Context, apiUrl string) sdpconnect.ConfigServiceClient {
+func AuthenticatedConfigurationClient(ctx context.Context, apiUrl string) sdpconnect.ConfigurationServiceClient {
 	httpClient := NewAuthenticatedClient(ctx, otelhttp.DefaultClient)
-	log.WithContext(ctx).WithField("apiUrl", apiUrl).Debug("Connecting to overmind config API (pre-authenticated)")
-	return sdpconnect.NewConfigServiceClient(httpClient, apiUrl)
+	log.WithContext(ctx).WithField("apiUrl", apiUrl).Debug("Connecting to overmind configuration API (pre-authenticated)")
+	return sdpconnect.NewConfigurationServiceClient(httpClient, apiUrl)
 }
 
 // AuthenticatedManagementClient Returns a bookmark client that uses the auth


### PR DESCRIPTION
The old ConfigService is deprecated and none of our code uses it anymore.