### PR TITLE
Added pagination calculation to utils for re-use

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,0 +1,25 @@
+package sdp
+
+import "math"
+
+// CalculatePaginationOffsetLimit Calculates the offset and limit for pagination
+// in SQL queries, along with the current page and total pages that should be
+// included in the response
+func CalculatePaginationOffsetLimit(pagination *PaginationRequest, totalItems int32) (offset, limit, page, totalPages int32) {
+	// pagesize is at least 10, at most 100
+	limit = min(100, max(10, pagination.GetPageSize()))
+	// calculate the total number of pages
+	totalPages = int32(math.Ceil(float64(totalItems) / float64(limit)))
+
+	// page has to be at least 1, and at most totalPages
+	page = min(totalPages, pagination.GetPage())
+	page = max(1, page)
+
+	// calculate the offset
+	if totalPages == 0 {
+		offset = 0
+	} else {
+		offset = (page * limit) - limit
+	}
+	return offset, limit, page, totalPages
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,48 @@
+package sdp
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCalculatePaginationOffsetLimit(t *testing.T) {
+	testCases := []struct {
+		page               int32
+		pageSize           int32
+		totalItems         int32
+		expectedOffset     int32
+		expectedLimit      int32
+		expectedPage       int32
+		expectedTotalPages int32
+	}{
+		{page: 2, pageSize: 10, totalItems: 20, expectedOffset: 10, expectedPage: 2, expectedLimit: 10, expectedTotalPages: 2},
+		{page: 3, pageSize: 10, totalItems: 25, expectedOffset: 20, expectedPage: 3, expectedLimit: 10, expectedTotalPages: 3},
+		{page: 0, pageSize: 5, totalItems: 15, expectedOffset: 0, expectedPage: 1, expectedLimit: 10, expectedTotalPages: 2},
+		{page: 5, pageSize: 7, totalItems: 23, expectedOffset: 20, expectedPage: 3, expectedLimit: 10, expectedTotalPages: 3},
+		{page: 1, pageSize: 10, totalItems: 0, expectedOffset: 0, expectedPage: 1, expectedLimit: 10, expectedTotalPages: 0},
+		{page: 1, pageSize: 10, totalItems: 3, expectedOffset: 0, expectedPage: 1, expectedLimit: 10, expectedTotalPages: 1},
+		{page: -1, pageSize: 10, totalItems: 1, expectedOffset: 0, expectedPage: 1, expectedLimit: 10, expectedTotalPages: 1},
+		{page: 1, pageSize: 101, totalItems: 1, expectedOffset: 0, expectedPage: 1, expectedLimit: 100, expectedTotalPages: 1},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("page%d pagesize%d totalItems%d", tc.page, tc.pageSize, tc.totalItems), func(t *testing.T) {
+			req := PaginationRequest{
+				Page:     tc.page,
+				PageSize: tc.pageSize,
+			}
+			offset, limit, correctedPage, pages := CalculatePaginationOffsetLimit(&req, tc.totalItems)
+			if offset != tc.expectedOffset {
+				t.Errorf("Expected offset %d, but got %d", tc.expectedOffset, offset)
+			}
+			if correctedPage != tc.expectedPage {
+				t.Errorf("Expected correctedPage %d, but got %d", tc.expectedPage, correctedPage)
+			}
+			if limit != tc.expectedLimit {
+				t.Errorf("Expected limit %d, but got %d", tc.expectedLimit, limit)
+			}
+			if pages != tc.expectedTotalPages {
+				t.Errorf("Expected pages %d, but got %d", tc.expectedTotalPages, pages)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a re-implementaion of the [`calculatePaginationOffsetLimit` function from api-server](https://github.com/overmindtech/api-server/blob/main/server/changesservice.go#L2939-L2956).

I'm moving this to SDP as I'm going to need the same logic in `gateway` and it makes sense to re-use it. Once this is merged I'll migrate the API-server to use this instead