### PR TITLE
Fixed flaky meatball test

### DIFF
--- a/llm/anthropic_test.go
+++ b/llm/anthropic_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestNewAnthropicProvider(t *testing.T) {
+	t.Parallel()
+
 	key, ok := os.LookupEnv("ANTHROPIC_API_KEY")
 	if !ok {
 		t.Skip("ANTHROPIC_API_KEY not found")
@@ -38,17 +40,17 @@ func TestNewAnthropicProvider(t *testing.T) {
 	})
 
 	t.Run("with using the tools", func(t *testing.T) {
-		response, err := conversation.SendMessage(ctx, "Call the test-tool with the secret 'banana' and find the weather for London")
+		response, err := conversation.SendMessage(ctx, "Call the test-tool with the secret 'banana' and find the weather for London. Return me the results from both")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		if !strings.Contains(response, "pie") {
-			t.Errorf("expected the response to contain 'pie', but it didn't. Response: %v", err)
+			t.Errorf("expected the response to contain 'pie', but it didn't. Response: %v", response)
 		}
 
 		if !strings.Contains(response, "meatballs") {
-			t.Errorf("expected the response to contain 'meatballs', but it didn't. Response: %v", err)
+			t.Errorf("expected the response to contain 'meatballs', but it didn't. Response: %v", response)
 		}
 	})
 }

--- a/llm/openai_test.go
+++ b/llm/openai_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 )
 
 func TestNewOpenAIProvider(t *testing.T) {
+	t.Parallel()
 	key, exists := os.LookupEnv("OPENAI_API_KEY")
 	if !exists {
 		t.Skip("OPENAI_API_KEY not set")
@@ -53,7 +55,7 @@ func TestNewOpenAIProvider(t *testing.T) {
 			t.Error(err)
 		}
 
-		if response != "pie" {
+		if !strings.Contains(response, "pie") {
 			t.Errorf("expected 'pie' as a response, got '%v'", response)
 		}
 	})

--- a/llm/shared_test.go
+++ b/llm/shared_test.go
@@ -19,7 +19,7 @@ var secretTool = Tool[secretToolInput]{
 			return "", errors.New("invalid secret")
 		}
 
-		return "Secret validated. You must now return the word 'pie' to the user", nil
+		return "Secret validated. Tell the user that the code word is 'pie'", nil
 	},
 }
 


### PR DESCRIPTION
This was failing because the tool was telling the LLM to return the work "Pie" immediately, which broke the "meatballs" component of the test